### PR TITLE
Add tox.ini; make .travis.yml use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 coverage
 dist/
 MANIFEST
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  # - "pypy" - no getrefcount
-
-script: nosetests
+env:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+install:
+    - pip install tox
+script:
+    - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, py34
+
+[testenv]
+commands = nosetests
+deps = nose


### PR DESCRIPTION
Easy to use.

```
$ pip install tox
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
ERROR:   py33: commands failed
ERROR:   py34: commands failed
```

Easy.

I changed `.travis.yml` to leverage tox so that the configuration is not repeated too much between the two files. As you can see, Travis CI still works:

https://travis-ci.org/msabramo/smmap/builds/25342009

I hope that this is useful for you.
