### PR TITLE
Change / to // (integer division) in several places

### DIFF
--- a/smmap/test/test_mman.py
+++ b/smmap/test/test_mman.py
@@ -95,8 +95,8 @@ class TestMMan(TestBase):
         fd = os.open(fc.path, os.O_RDONLY)
         max_num_handles = 15
         #small_size = 
-        for mtype, args in ( (StaticWindowMapManager, (0, fc.size / 3, max_num_handles)),
-                            (SlidingWindowMapManager, (fc.size / 100, fc.size / 3, max_num_handles)),):
+        for mtype, args in ( (StaticWindowMapManager, (0, fc.size // 3, max_num_handles)),
+                            (SlidingWindowMapManager, (fc.size // 100, fc.size // 3, max_num_handles)),):
             for item in (fc.path, fd):
                 assert len(data) == fc.size
                 
@@ -110,7 +110,7 @@ class TestMMan(TestBase):
                 
                 base_offset = 5000
                 # window size is 0 for static managers, hence size will be 0. We take that into consideration
-                size = man.window_size() / 2
+                size = man.window_size() // 2
                 assert c.use_region(base_offset, size).is_valid()
                 rr = c.region_ref()
                 assert rr().client_count() == 2 # the manager and the cursor and us

--- a/smmap/test/test_util.py
+++ b/smmap/test/test_util.py
@@ -54,7 +54,7 @@ class TestMMan(TestBase):
         
     def test_region(self):
         fc = FileCreator(self.k_window_test_size, "window_test")
-        half_size = fc.size / 2
+        half_size = fc.size // 2
         rofs = align_to_mmap(4200, False)
         rfull = MapRegion(fc.path, 0, fc.size)
         rhalfofs = MapRegion(fc.path, rofs, fc.size)

--- a/smmap/util.py
+++ b/smmap/util.py
@@ -31,7 +31,7 @@ def align_to_mmap(num, round_up):
     :param round_up: if True, the next higher multiple of page size is used, otherwise
         the lower page_size will be used (i.e. if True, 1 becomes 4096, otherwise it becomes 0)
     :return: num rounded to closest page"""
-    res = (num / ALLOCATIONGRANULARITY) * ALLOCATIONGRANULARITY;
+    res = (num // ALLOCATIONGRANULARITY) * ALLOCATIONGRANULARITY;
     if round_up and (res != num):
         res += ALLOCATIONGRANULARITY
     #END handle size


### PR DESCRIPTION
This fixes a bunch of bugs and test failures in Python 3, which uses "true division" for /
