### PR TITLE
Add back tox.ini for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, py34
+
+[testenv]
+commands = nosetests {posargs:--with-coverage --cover-package=smmap}
+deps =
+    nose
+    nosexcover


### PR DESCRIPTION
This time with support for measuring coverage.
Ability to test quickly across multiple Python versions is crucial for
working on Python 3 compatibility...
