### PR TITLE
.travis.yml: Allow py33 to fail, add py34, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
 install:
   - pip install coveralls
 script:
   - nosetests --with-coverage
 after_success:
   - coveralls
+matrix:
+  allow_failures:
+    - python: 3.3
+    - python: 3.4
+  fast_finish: true


### PR DESCRIPTION
Add python 3.4 and allow python 3.3 and python 3.4 tests to fail until we fix them.
