### PR TITLE
Make __getitem__ handle slice for Python 3

### DIFF
--- a/smmap/buf.py
+++ b/smmap/buf.py
@@ -51,6 +51,8 @@ class SlidingWindowMapBuffer(object):
         return self._size
         
     def __getitem__(self, i):
+        if isinstance(i, slice):
+            return self.__getslice__(i.start or 0, i.stop or self._size)
         c = self._c
         assert c.is_valid()
         if i < 0:


### PR DESCRIPTION
Python 3 doesn't have `__getslice__` instead it uses `__getitem__` with a `slice` object.

http://python3porting.com/differences.html#slice-operator-methods
https://docs.python.org/3/howto/pyporting.html#don-t-use-getslice-friends
https://docs.python.org/2/reference/datamodel.html#object.__getslice__
