### PR TITLE
Change / to // (integer division) in test_buf.py

### DIFF
--- a/smmap/test/test_buf.py
+++ b/smmap/test/test_buf.py
@@ -10,9 +10,10 @@ import os
 
 
 man_optimal = SlidingWindowMapManager()
-man_worst_case = SlidingWindowMapManager(   window_size=TestBase.k_window_test_size/100, 
-                                    max_memory_size=TestBase.k_window_test_size/3, 
-                                    max_open_handles=15)
+man_worst_case = SlidingWindowMapManager(
+    window_size=TestBase.k_window_test_size // 100,
+    max_memory_size=TestBase.k_window_test_size // 3,
+    max_open_handles=15)
 static_man = StaticWindowMapManager()
 
 class TestBuf(TestBase):


### PR DESCRIPTION
This fixes (the last!) test failure in Python 3, which uses "true division" for /

```
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  congratulations :)
```
