### PR TITLE
Add MANIFEST.in to include LICENSE in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# Include the license file
+include LICENSE


### PR DESCRIPTION
From https://packaging.python.org/distributing/#manifest-in:
> A "MANIFEST.in" is needed in certain cases where you need to package
> additional files that python setup.py sdist (or bdist_wheel) don't
> automatically include.