### PR TITLE
Drop support for EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: python
 python:
-  # These versions are unsupported by travis, even though smmap claims to still support these outdated versions
-  # - 2.4
-  # - 2.5
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
 install:
   - pip install coveralls
 script:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Although memory maps have many advantages, they represent a very limited system 
 
 * **System resources (file-handles) are likely to be leaked!** This is due to the library authors reliance on a deterministic `__del__()` destructor.
 * The memory access is read-only by design.
-* In python below 2.6, memory maps will be created in compatibility mode which works, but creates inefficient memory mappings as they always start at offset 0.
 
 
 ## Overview
@@ -34,7 +33,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 
 ## Prerequisites
 
-* Python 2.4, 2.5, 2.6, 2.7 or 3.3
+* Python 2.7 or 3.4+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -22,7 +22,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 #############
 Prerequisites
 #############
-* Python 2.4, 2.5, 2.6, 2.7 or 3.3
+* Python 2.7 or 3.4+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.
@@ -31,7 +31,6 @@ The package was tested on all of the previously mentioned configurations.
 Limitations
 ###########
 * The memory access is read-only by design.
-* In python below 2.6, memory maps will be created in compatibility mode which works, but creates inefficient memory mappings as they always start at offset 0.
 
 ################
 Installing smmap

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     zip_safe=True,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     classifiers=[
         # Picked from
         #    http://pypi.python.org/pypi?:action=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ import smmap
 if os.path.exists("README.md"):
     long_description = codecs.open('README.md', "r", "utf-8").read()
 else:
-    long_description = "See http://github.com/gitpython-developers/smmap"
+    long_description = "See https://github.com/gitpython-developers/smmap"
 
 setup(
     name="smmap2",
     version=smmap.__version__,
-    description="A pure python implementation of a sliding window memory map manager",
+    description="A pure Python implementation of a sliding window memory map manager",
     author=smmap.__author__,
     author_email=smmap.__contact__,
     url=smmap.__homepage__,
@@ -45,10 +45,8 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/smmap/buf.py
+++ b/smmap/buf.py
@@ -88,35 +88,20 @@ class SlidingWindowMapBuffer(object):
             # It's fastest to keep tokens and join later, especially in py3, which was 7 times slower
             # in the previous iteration of this code
             pyvers = sys.version_info[:2]
-            if (3, 0) <= pyvers <= (3, 3):
-                # Memory view cannot be joined below python 3.4 ...
-                out = bytes()
-                while l:
-                    c.use_region(ofs, l)
-                    assert c.is_valid()
-                    d = c.buffer()[:l]
-                    ofs += len(d)
-                    l -= len(d)
-                    # This is slower than the join ... but what can we do ...
-                    out += d
-                    del(d)
-                # END while there are bytes to read
-                return out
-            else:
-                md = list()
-                while l:
-                    c.use_region(ofs, l)
-                    assert c.is_valid()
-                    d = c.buffer()[:l]
-                    ofs += len(d)
-                    l -= len(d)
-                    # Make sure we don't keep references, as c.use_region() might attempt to free resources, but
-                    # can't unless we use pure bytes
-                    if hasattr(d, 'tobytes'):
-                        d = d.tobytes()
-                    md.append(d)
-                # END while there are bytes to read
-                return bytes().join(md)
+            md = list()
+            while l:
+                c.use_region(ofs, l)
+                assert c.is_valid()
+                d = c.buffer()[:l]
+                ofs += len(d)
+                l -= len(d)
+                # Make sure we don't keep references, as c.use_region() might attempt to free resources, but
+                # can't unless we use pure bytes
+                if hasattr(d, 'tobytes'):
+                    d = d.tobytes()
+                md.append(d)
+            # END while there are bytes to read
+            return bytes().join(md)
         # END fast or slow path
     #{ Interface
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py26, py27, py33, py34
+envlist = flake8, py27, py34
 
 [testenv]
 commands = nosetests {posargs:--with-coverage --cover-package=smmap}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py27, py34
+envlist = flake8, py27, py34, py35, py36
 
 [testenv]
 commands = nosetests {posargs:--with-coverage --cover-package=smmap}


### PR DESCRIPTION
Python 2.4-2.6 and 3.3 are EOL (since 2008-12-19, 2011-05-26 , 2013-10-29 and 2017-09-29 respectively) and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for smmap2 from PyPI for August 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  74.22% |      1,236,793 |
| 3.6            |  15.60% |        260,009 |
| 3.5            |   5.87% |         97,879 |
| 3.4            |   2.88% |         47,933 |
| 3.7            |   1.39% |         23,240 |
| 2.6            |   0.02% |            365 |
| 3.3            |   0.01% |            213 |
| 3.8            |   0.00% |             56 |
| None           |   0.00% |              2 |
| Total          |         |      1,666,490 |

Source: `pypinfo --start-date 2018-08-01 --end-date 2018-08-31 --json smmap2 pyversion`