### PR TITLE
Tell PyPI long_description is Markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     long_description=long_description,
+    long_description_content_type='text/markdown',
     tests_require=('nose', 'nosexcover'),
     test_suite='nose.collector'
 )


### PR DESCRIPTION
Rendering of the README on PyPI is broken because it expects RST by default and Markdown is being uploaded. This fixes it.