### PR TITLE
Add support for Python 3.10, drop EOL 3.5

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         fetch-depth: 1000
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -35,9 +35,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with nose
+    - name: Test
       run: |
-        pip install nose
+        pip install pytest
         ulimit -n 48
         ulimit -n
-        nosetests -v
+        pytest -v

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ clean-files:
 clean: clean-files clean-docs
 
 test:
-	nosetests
+	pytest
 
 coverage:
-	nosetests --with-coverage --cover-package=smmap
-	
+	pytest --cov smmap --cov-report xml
+
 build:
 	./setup.py build
 	

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 
 ## Prerequisites
 
-* Python 3.5+
+* Python 3.6+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # smmap documentation build configuration file, created by
 # sphinx-quickstart on Wed Jun  8 15:14:25 2011.
@@ -38,8 +37,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'smmap'
-copyright = u'2011, Sebastian Thiel'
+project = 'smmap'
+copyright = '2011, Sebastian Thiel'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -173,8 +172,8 @@ htmlhelp_basename = 'smmapdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'smmap.tex', u'smmap Documentation',
-     u'Sebastian Thiel', 'manual'),
+    ('index', 'smmap.tex', 'smmap Documentation',
+     'Sebastian Thiel', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -20,7 +20,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 #############
 Prerequisites
 #############
-* Python 3.5+
+* Python 3.6+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = .tox,.venv,build,dist,doc

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 import smmap
 
 if os.path.exists("README.md"):
-    long_description = open('README.md', "r", encoding="utf-8").read().replace('\r\n', '\n')
+    long_description = open('README.md', encoding="utf-8").read().replace('\r\n', '\n')
 else:
     long_description = "See https://github.com/gitpython-developers/smmap"
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     zip_safe=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -38,7 +38,6 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
     ],
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,4 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type='text/markdown',
-    tests_require=('nose', 'nosexcover'),
-    test_suite='nose.collector'
 )

--- a/smmap/buf.py
+++ b/smmap/buf.py
@@ -4,7 +4,7 @@ import sys
 __all__ = ["SlidingWindowMapBuffer"]
 
 
-class SlidingWindowMapBuffer(object):
+class SlidingWindowMapBuffer:
 
     """A buffer like object which allows direct byte-wise object and slicing into
     memory of a mapped file. The mapping is controlled by the provided cursor.

--- a/smmap/mman.py
+++ b/smmap/mman.py
@@ -15,7 +15,7 @@ __all__ = ["StaticWindowMapManager", "SlidingWindowMapManager", "WindowCursor"]
 #}END utilities
 
 
-class WindowCursor(object):
+class WindowCursor:
 
     """
     Pointer into the mapped region of the memory manager, keeping the map
@@ -233,7 +233,7 @@ class WindowCursor(object):
     #} END interface
 
 
-class StaticWindowMapManager(object):
+class StaticWindowMapManager:
 
     """Provides a manager which will produce single size cursors that are allowed
     to always map the whole file.
@@ -486,7 +486,7 @@ class SlidingWindowMapManager(StaticWindowMapManager):
 
     def __init__(self, window_size=-1, max_memory_size=0, max_open_handles=sys.maxsize):
         """Adjusts the default window size to -1"""
-        super(SlidingWindowMapManager, self).__init__(window_size, max_memory_size, max_open_handles)
+        super().__init__(window_size, max_memory_size, max_open_handles)
 
     def _obtain_region(self, a, offset, size, flags, is_recursive):
         # bisect to find an existing region. The c++ implementation cannot

--- a/smmap/test/lib.py
+++ b/smmap/test/lib.py
@@ -8,7 +8,7 @@ __all__ = ['TestBase', 'FileCreator']
 
 #{ Utilities
 
-class FileCreator(object):
+class FileCreator:
 
     """A instance which creates a temporary file with a prefix and a given size
     and provides this info to the user.

--- a/smmap/test/test_buf.py
+++ b/smmap/test/test_buf.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from .lib import TestBase, FileCreator
 
 from smmap.mman import (

--- a/smmap/test/test_mman.py
+++ b/smmap/test/test_mman.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from .lib import TestBase, FileCreator
 
 from smmap.mman import (

--- a/smmap/util.py
+++ b/smmap/util.py
@@ -34,7 +34,7 @@ def is_64_bit():
 
 #{ Utility Classes
 
-class MapWindow(object):
+class MapWindow:
 
     """Utility type which is used to snap windows towards each other, and to adjust their size"""
     __slots__ = (
@@ -80,7 +80,7 @@ class MapWindow(object):
         self.size = min(self.size + (window.ofs - self.ofs_end()), max_size)
 
 
-class MapRegion(object):
+class MapRegion:
 
     """Defines a mapped region of memory, aligned to pagesizes
 
@@ -198,7 +198,7 @@ class MapRegionList(list):
     )
 
     def __new__(cls, path):
-        return super(MapRegionList, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, path_or_fd):
         self._path_or_fd = path_or_fd

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py36, py37, py38, py39
+envlist = flake8, py36, py37, py38, py39, py310
 
 [testenv]
 commands = nosetests {posargs:--with-coverage --cover-package=smmap}

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@
 envlist = flake8, py36, py37, py38, py39, py310
 
 [testenv]
-commands = nosetests {posargs:--with-coverage --cover-package=smmap}
+commands = {envpython} -m pytest --cov smmap --cov-report xml {posargs}
 deps =
-    nose
-    nosexcover
+    pytest
+    pytest-cov
 
 [testenv:flake8]
 commands = flake8 {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py35, py36, py37, py38, py39
+envlist = flake8, py36, py37, py38, py39
 
 [testenv]
 commands = nosetests {posargs:--with-coverage --cover-package=smmap}


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

We can also take the opportunity to drop EOL Python 3.5, and upgrade Python syntax for 3.6+.

nose is abandoned and unmaintained, last release was 6.5 years ago (https://pypi.org/project/nose/) and it no longer works with Python 3.10 (https://github.com/nose-devs/nose/issues/1099). So let's switch to pytest.

We also don't need to create universal wheels, they're for supporting Python 2 and 3.

