### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1000
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 
 ## Prerequisites
 
-* Python 3.6+
+* Python 3.7+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -20,7 +20,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 #############
 Prerequisites
 #############
-* Python 3.6+
+* Python 3.7+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     zip_safe=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -38,7 +38,6 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/smmap/buf.py
+++ b/smmap/buf.py
@@ -93,7 +93,7 @@ class SlidingWindowMapBuffer:
                     d = d.tobytes()
                 md.append(d)
             # END while there are bytes to read
-            return bytes().join(md)
+            return b''.join(md)
         # END fast or slow path
     #{ Interface
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py{36, 37, 38, 39, 310, 311}
+envlist = flake8, py{37, 38, 39, 310, 311}
 
 [testenv]
 commands = {envpython} -m pytest --cov smmap --cov-report xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py36, py37, py38, py39, py310
+envlist = flake8, py{36, 37, 38, 39, 310, 311}
 
 [testenv]
 commands = {envpython} -m pytest --cov smmap --cov-report xml {posargs}


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

And drop EOL Python 3.6 and bump GitHub Actions.
