### PR TITLE
Add support for Python 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1000
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,6 +25,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 
 ## Prerequisites
 
-* Python 3.7+
+* Python 3.8+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -20,7 +20,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 #############
 Prerequisites
 #############
-* Python 3.7+
+* Python 3.8+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     zip_safe=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -38,7 +38,6 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
     ],
     long_description=long_description,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py{37, 38, 39, 310, 311, 312}
+envlist = flake8, py{38, 39, 310, 311, 312}
 
 [testenv]
 commands = {envpython} -m pytest --cov smmap --cov-report xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py{37, 38, 39, 310, 311}
+envlist = flake8, py{37, 38, 39, 310, 311, 312}
 
 [testenv]
 commands = {envpython} -m pytest --cov smmap --cov-report xml {posargs}


### PR DESCRIPTION
The [second and final Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
