### PR TITLE
Revert "Drop support for EOL Python 3.7"

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 
 ## Prerequisites
 
-* Python 3.8+
+* Python 3.7+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -20,7 +20,7 @@ For performance critical 64 bit applications, a simplified version of memory map
 #############
 Prerequisites
 #############
-* Python 3.8+
+* Python 3.7+
 * OSX, Windows or Linux
 
 The package was tested on all of the previously mentioned configurations.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     zip_safe=True,
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -38,6 +38,7 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py{38, 39, 310, 311, 312}
+envlist = flake8, py{37, 38, 39, 310, 311, 312}
 
 [testenv]
 commands = {envpython} -m pytest --cov smmap --cov-report xml {posargs}


### PR DESCRIPTION
Analogous to https://github.com/gitpython-developers/gitdb/pull/94, this brings back Python 3.7 support (allowing it to be installed on 3.7, and testing on 3.7), even though 3.7 is end of life, because support for 3.7 is not being dropped by GitPython (or gitdb) yet, and there is value in keeping GitPython, gitdb, and smmap consistent.

This reverts commit f1b4d14e7d3902135af336ed06a12308dfd40270.

---

Discussion relevant to determining whether this should be merged, as well as whether a new release should be made after doing so if it is, begins at https://github.com/gitpython-developers/smmap/issues/51#issuecomment-1722425851.