### PR TITLE
Update CI, in line with gitdb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "weekly"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,19 +16,23 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          - experimental: false
+          - python-version: "3.12"
+            experimental: true
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1000
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-    - name: Install dependencies
+        allow-prereleases: ${{ matrix.experimental }}
+    - name: Install project
       run: |
         python -m pip install --upgrade pip
+        pip install .
     - name: Lint with flake8
       run: |
         pip install flake8


### PR DESCRIPTION
This updates `smmap`'s CI configuration in ways that are in line with recent updates to `gitdb`'s. In most cases there is no difference in the changes, and the reason for the updates is more to avoid confusing differences than from the value of the changes themselves. In one case, there is a major difference (`fetch-depth`), and I think the change there is clarifying, at least when the repositories are compared.

`gitdb` PRs these changes correspond to:

- https://github.com/gitpython-developers/gitdb/pull/89 (same)
- https://github.com/gitpython-developers/gitdb/pull/90 (same)
  It's just the project, not dependencies, but otherwise the same.
- https://github.com/gitpython-developers/gitdb/pull/92 (opposite)
  This is the major difference. We don't need more than the tip of the branch in these tests. Keeping the default `fetch-depth` of 1 by not setting it explicitly avoids giving the impression that the tests here are doing something they are not (and also serves as a speed optimization).
- https://github.com/gitpython-developers/gitdb/pull/93 (same)

As noted in https://github.com/gitpython-developers/gitdb/pull/91#issuecomment-1713488422, I don't intend to spend a lot of time proposing new features for `gitdb` and `smmap`. Having just done #52, which corresponds to https://github.com/gitpython-developers/gitdb/pull/94, it was bugging me a bit that I had arbitrarily proposed the other changes in `gitdb` but not here.