### PR TITLE
No longer treat 3.12 as experimental on smmap CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,8 +14,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
         - experimental: false
-        - python-version: "3.12"
-          experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -17,9 +13,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          - experimental: false
-          - python-version: "3.12"
-            experimental: true
+        - experimental: false
+        - python-version: "3.12"
+          experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:


### PR DESCRIPTION
Now that Python 3.12.0 has a stable release and is available.

This makes the same changes as in **https://github.com/gitpython-developers/gitdb/pull/97** and for the same reasons, including running CI on all branches. As there, I can remove that part if you don't want it.

(For posterity and cross-linking, I note also that this is related to https://github.com/gitpython-developers/GitPython/pull/1689.)