### PR TITLE
Replace use of mktemp

### DIFF
--- a/smmap/test/lib.py
+++ b/smmap/test/lib.py
@@ -18,12 +18,12 @@ class FileCreator:
     def __init__(self, size, prefix=''):
         assert size, "Require size to be larger 0"
 
-        self._path = tempfile.mktemp(prefix=prefix)
         self._size = size
 
-        with open(self._path, "wb") as fp:
-            fp.seek(size - 1)
-            fp.write(b'1')
+        with tempfile.NamedTemporaryFile("wb", prefix=prefix, delete=False) as file:
+            self._path = file.name
+            file.seek(size - 1)
+            file.write(b'1')
 
         assert os.path.getsize(self.path) == size
 


### PR DESCRIPTION
Fixes #41

This uses `NamedTemporaryFile` with `delete=False` to replace the one use of the deprecated `mktemp` function in smmap (reported in #41).

This avoids the race condition inherent to `mktemp`, as the file is named and created together in a way that is effectively atomic.

Because `NamedTemporaryFile` is not being used to automatically delete the file, it use and cleanup are unaffected by the change.

(This PR is conceptually related to https://github.com/gitpython-developers/GitPython/pull/1770.)