### PR TITLE
Test Python 3.7 on Ubuntu 22.04, and add Ubuntu 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,13 +7,17 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
         - experimental: false
+        - os: ubuntu-latest
+        - python-version: "3.7"
+          os: ubuntu-22.04
+
+    runs-on: ${{ matrix.os }}
+
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
     ],
     long_description=long_description,


### PR DESCRIPTION
This is analogous to the gitdb test workflow and `setup.py` updates in https://github.com/gitpython-developers/gitdb/pull/114.

1. Testing 3.7 on 22.04 rather than 24.04 should fix the problem where it fails because Python 3.7 is not available.
2. Adding Ubuntu 3.13 to CI may help reveal if there are 3.13-specific problems with smmap.
3. smmap seems to be working on Python 3.13 (which is a stable Python release) and there are no specific expected problems with it, so this adds it to the list of supported releases.

In particular, this change, due to (1), fixes the current CI failure for smmap observed in f31bfa3.

---

It looks like changes along the lines of (1), in addition to some other changes, will need to be made in GitPython in order to fix some recent breakages in its CI.

This relates to the CI breakages noted in the comment posted on https://github.com/gitpython-developers/GitPython/commit/e51bf80ad576256f2fbeead41ea3f0b667c77055.