### PR TITLE
Add SECURITY.md, referencing the GitPython one

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+See [GitPython](https://github.com/gitpython-developers/GitPython/blob/main/SECURITY.md). Vulnerabilities found in `smmap` can be reported there.


### PR DESCRIPTION
This will fix https://github.com/gitpython-developers/gitdb/issues/116, when taken together with related forthcoming PRs in the gitdb and GitPython repositories.

I don't know if you want to include information about the specific versions that are supported. Readers may infer this from a combination of the way it works as described in the GitPython policy and what versions of `smmap` exist, I am not sure. I kept the file minimal for now.