### PR TITLE
Specify explicit `contents: read` workflow permissions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,6 +5,9 @@ name: Python package
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This change is analogous to gitpython-developers/GitPython#2033.

See also gitpython-developers/gitdb#121.