### PR TITLE
Add CI test job for no-GIL ("threaded") Python 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
         include:
         - experimental: false
         - os: ubuntu-latest


### PR DESCRIPTION
See https://github.com/gitpython-developers/GitPython/issues/2005, and https://github.com/gitpython-developers/gitdb/pull/122 for rationale. In short, if the corresponding check starts to fail in GitPython, it may be useful to observe if there is a failure here as well.